### PR TITLE
Update release workflow: support `main`, enable manual dispatch, generate `.releaserc.json`, use Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,12 @@
-# Workflow: Release Otomatis (Semantic Release) untuk Library PHP
-#
-# Deskripsi:
-#   Workflow ini berjalan setiap kali ada push ke branch `master` (bukan `main`).
-#   Ia akan menganalisis commit-commit baru, menentukan versi rilis
-#   berikutnya berdasarkan aturan Semantic Versioning (major.minor.patch),
-#   membuat Git tag, dan menerbitkan GitHub Release.
-#
-#   Aturan penentuan versi:
-#   - Commit dengan `fix:`        → bump patch (1.2.3 → 1.2.4)
-#   - Commit dengan `feat:`       → bump minor (1.2.3 → 1.3.0)
-#   - Commit dengan `BREAKING CHANGE:` atau tanda `!` setelah tipe
-#                                 → bump major (1.2.3 → 2.0.0)
-#
-# Catatan:
-#   Pastikan Anda menggunakan format commit Conventional Commits.
-#   Token GITHUB_TOKEN sudah tersedia otomatis di Actions.
-
 name: Release Otomatis (Semantic Release)
 
-# Jalankan workflow ketika ada push ke branch master (default branch repositori)
 on:
   push:
     branches:
+      - main
       - master
+  workflow_dispatch:
 
-# Izin yang diperlukan untuk membuat release dan tag
 permissions:
   contents: write
   issues: write
@@ -35,34 +17,39 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # 1. Checkout repository dengan riwayat penuh (agar semantic-release bisa
-      #    melihat commit dan tag sebelumnya)
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      # 2. Setup Node.js (dibutuhkan oleh semantic-release yang berjalan di atas Node)
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: '20'
 
-      # 3. Install semantic-release dan plugin yang diperlukan
-      #    (plugin tambahan bisa disesuaikan, yang di bawah sudah mencukupi)
       - name: Install semantic-release dan plugin
         run: |
-          npm init -y
-          npm install --save-dev \
+          npm install --no-save \
             semantic-release \
             @semantic-release/commit-analyzer \
             @semantic-release/release-notes-generator \
-            @semantic-release/github \
-            @semantic-release/git
+            @semantic-release/github
 
-      # 4. Jalankan semantic-release
-      #    Environment variable GITHUB_TOKEN sudah otomatis tersedia
+      - name: Generate release config (tanpa npm publish)
+        run: |
+          cat > .releaserc.json <<JSON
+          {
+            "branches": ["main", "master"],
+            "repositoryUrl": "https://github.com/${GITHUB_REPOSITORY}.git",
+            "plugins": [
+              "@semantic-release/commit-analyzer",
+              "@semantic-release/release-notes-generator",
+              "@semantic-release/github"
+            ]
+          }
+          JSON
+
       - name: Jalankan semantic-release
-        run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release


### PR DESCRIPTION
### Motivation

- Ensure the release workflow works for repositories using `main` and allow manual triggers via `workflow_dispatch`.
- Use a stable Node version (`20`) and avoid creating/updating a local `package.json` by installing packages with `--no-save`.
- Centralize `semantic-release` configuration into a generated `.releaserc.json` and remove unnecessary `@semantic-release/git` usage.

### Description

- Added `main` to the `push.branches` list and enabled `workflow_dispatch` to allow manual runs.
- Updated the Node setup to use `node-version: '20'` and changed the install step to `npm install --no-save` instead of initializing a package with `npm init -y`.
- Added a step that generates a `.releaserc.json` with `branches`, `repositoryUrl`, and the `semantic-release` plugins, and removed `@semantic-release/git` from the installed plugins list.
- Kept `actions/checkout@v4` with `fetch-depth: 0` and retained the `npx semantic-release` execution using the `GITHUB_TOKEN` environment variable.

### Testing

- No automated tests were added or modified because this change only updates the CI workflow configuration.
- The updated workflow was not executed as part of this PR, so there are no CI run results to report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1650b12fb08322b7be2ab4c299b778)